### PR TITLE
Add support for numeric ranges and datetimes.

### DIFF
--- a/l2cs.py
+++ b/l2cs.py
@@ -163,6 +163,7 @@ class IntNodePlugin(PseudoFieldPlugin):
             except ValueError:
                 return None
         else:
+            node.set_fieldname(fieldname)
             return node
 
 
@@ -176,6 +177,7 @@ class YesNoPlugin(PseudoFieldPlugin):
             new_node.set_fieldname(fieldname)
             return new_node
         else:
+            node.set_fieldname(fieldname)
             return node
 
 
@@ -189,8 +191,7 @@ class FieldAliasPlugin(PseudoFieldPlugin):
         super(FieldAliasPlugin, self).__init__(self.aliases.keys())
     
     def modify_node(self, fieldname, node):
-        if node.has_text:
-            node.set_fieldname(self.aliases[fieldname])
+        node.set_fieldname(self.aliases[fieldname])
         return node
 
 

--- a/test_l2cs.py
+++ b/test_l2cs.py
@@ -141,6 +141,20 @@ class l2csTester(unittest.TestCase):
         result = l2cs.convert(u'foo:\u0ca0_\u0ca0', self.parser)
         self.assertIsInstance(result, unicode)
     
+    # Numeric ranges
+    def test_range1(self):
+        self._run_test(u"number:[0 TO 20]", u"number:0..20", self.schema_parser)
+    
+    # Dates
+    def test_date1(self):
+        self._run_test(u"date:1970", u"date:0..31535999", self.schema_parser)
+    
+    def test_date2(self):
+        self._run_test(u"date:201002", u"date:1264982400..1267401599", self.schema_parser)
+    
+    def test_date3(self):
+        self._run_test(u"date:'Sept 2 2012 to sept 3 2012 5:13 PM'", u"date:1346544000..1346692439", self.schema_parser)
+    
     ### Test cases from resolved issues ###
     # The remaining test cases protect against issues that have been resolved
     


### PR DESCRIPTION
This adds support for using numeric ranges (#20) and datetimes (#3).

Note that all searches are treated as inclusive (rather than using `[` vs `{` and `}` vs `]`), since CloudSearch doesn't have exclusive searches. 
